### PR TITLE
Ensure that a valid domain is returned from parse-domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,60 +132,61 @@ if (Args.help || Args.h) {
                                             if (tweet.entities.urls.length > 0) {
                                                 tweet.entities.urls.forEach((url) => {
                                                     const domain = Domain(url.expanded_url);
+                                                    if (domain) {
+                                                        queue(`${domain.domain}.${domain.tld}`, Path.basename(file), new Promise((fulfill) => {
+                                                            let done = 0;
 
-                                                    queue(`${domain.domain}.${domain.tld}`, Path.basename(file), new Promise((fulfill) => {
-                                                        let done = 0;
+                                                            whoisLookup(`${domain.domain}.${domain.tld}`)
+                                                                .then((expiry) => {
+                                                                    if (Args.v || Args.verbose) console.log(`${'whois'.bold.gray} ${domain.domain}.${domain.tld} expires at ${expiry}`);
 
-                                                        whoisLookup(`${domain.domain}.${domain.tld}`)
-                                                            .then((expiry) => {
-                                                                if (Args.v || Args.verbose) console.log(`${'whois'.bold.gray} ${domain.domain}.${domain.tld} expires at ${expiry}`);
+                                                                    const expiresIn = new Date(expiry) - Date.now();
 
-                                                                const expiresIn = new Date(expiry) - Date.now();
-
-                                                                if (expiresIn < 0) {
-                                                                    fulfill(`${'whois'.bold.yellow.bgRed} ${domain.domain}.${domain.tld} expired ${Math.abs(Math.round(expiresIn / 1000 / 60 / 60 / 24))} days ago!`);
-                                                                    claimableDomains.push(domain);
-                                                                } else if (expiresIn < 1000 * 60 * 60 * 24 * 3) { // if expiry in under 3 days
-                                                                    fulfill(`${'whois'.bold.yellow} ${domain.domain}.${domain.tld} expires in ${Math.round(expiresIn / 1000 / 60 / 60 / 24)} days at ${expiry}.`);
-                                                                    claimableDomains.push(domain);
-                                                                }
-
-                                                                done += 1;
-
-                                                                if (done === 2) {
-                                                                    fulfill();
-                                                                }
-                                                            })
-                                                            .catch((error) => {
-                                                                done += 1;
-
-                                                                if (done === 2) {
-                                                                    fulfill();
-                                                                }
-
-                                                                console.log(`${'whois'.red.bold} ${error} on ${domain.domain}.${domain.tld}`);
-                                                            });
-
-                                                        takeoverLookup(`http://${domain.subdomain ? `${domain.subdomain}.` : ''}${domain.domain}.${domain.tld}`)
-                                                            .then((takeoverHost) => {
-                                                                if (takeoverHost) {
-                                                                    console.log(`${'takeover'.bold.yellow.bgRed} ${domain.subdomain ? `${domain.subdomain}.` : ''}${domain.domain}.${domain.tld} can be taken over, host: ${takeoverHost}`);
+                                                                    if (expiresIn < 0) {
+                                                                        fulfill(`${'whois'.bold.yellow.bgRed} ${domain.domain}.${domain.tld} expired ${Math.abs(Math.round(expiresIn / 1000 / 60 / 60 / 24))} days ago!`);
+                                                                        claimableDomains.push(domain);
+                                                                    } else if (expiresIn < 1000 * 60 * 60 * 24 * 3) { // if expiry in under 3 days
+                                                                        fulfill(`${'whois'.bold.yellow} ${domain.domain}.${domain.tld} expires in ${Math.round(expiresIn / 1000 / 60 / 60 / 24)} days at ${expiry}.`);
+                                                                        claimableDomains.push(domain);
+                                                                    }
 
                                                                     done += 1;
 
                                                                     if (done === 2) {
                                                                         fulfill();
                                                                     }
-                                                                }
-                                                            })
-                                                            .catch(() => {
-                                                                done += 1;
+                                                                })
+                                                                .catch((error) => {
+                                                                    done += 1;
 
-                                                                if (done === 2) {
-                                                                    fulfill();
-                                                                }
-                                                            });
-                                                    }));
+                                                                    if (done === 2) {
+                                                                        fulfill();
+                                                                    }
+
+                                                                    console.log(`${'whois'.red.bold} ${error} on ${domain.domain}.${domain.tld}`);
+                                                                });
+
+                                                            takeoverLookup(`http://${domain.subdomain ? `${domain.subdomain}.` : ''}${domain.domain}.${domain.tld}`)
+                                                                .then((takeoverHost) => {
+                                                                    if (takeoverHost) {
+                                                                        console.log(`${'takeover'.bold.yellow.bgRed} ${domain.subdomain ? `${domain.subdomain}.` : ''}${domain.domain}.${domain.tld} can be taken over, host: ${takeoverHost}`);
+
+                                                                        done += 1;
+
+                                                                        if (done === 2) {
+                                                                            fulfill();
+                                                                        }
+                                                                    }
+                                                                })
+                                                                .catch(() => {
+                                                                    done += 1;
+
+                                                                    if (done === 2) {
+                                                                        fulfill();
+                                                                    }
+                                                                });
+                                                        }));
+                                                    }
                                                 });
                                             }
                                         });


### PR DESCRIPTION
Added if statement (lines 135 & 189), but adjusted indentation.

parse domain fails when an `@` is present in the middle of a string (expected) as urls can contain user information for auth purposes.

URL that surfaced the bug: `http://www.flickr.com/photos/25555668@N00/4283411453`